### PR TITLE
add label btn

### DIFF
--- a/dashboard/enums.py
+++ b/dashboard/enums.py
@@ -1,5 +1,7 @@
 from enum import IntEnum
+
 from last.services.enums import Method
+
 
 class ProductType(IntEnum):
     article = 1

--- a/dashboard/enums.py
+++ b/dashboard/enums.py
@@ -1,7 +1,5 @@
 from enum import IntEnum
 
-from last.services.enums import Method
-
 
 class ProductType(IntEnum):
     article = 1

--- a/dashboard/enums.py
+++ b/dashboard/enums.py
@@ -1,5 +1,5 @@
 from enum import IntEnum
-
+from last.services.enums import Method
 
 class ProductType(IntEnum):
     article = 1

--- a/dashboard/models.py
+++ b/dashboard/models.py
@@ -97,6 +97,6 @@ class Dog1(Model):
 
 class LabelPage(Model):
     task_type = fields.CharField(max_length=50)
-    labeling_method = fields.JSONField()
+    labeling_method = fields.CharField(max_length=255)
     release_time = fields.DatetimeField()
     current_status = fields.CharField(max_length=50)

--- a/dashboard/resources.py
+++ b/dashboard/resources.py
@@ -82,16 +82,16 @@ class Dataset(Dropdown):
         filters = [filters.Search(name="task_type", label="Task Type")]
         fields = ["id", "task_type", "labeling_method", "release_time", "current_status"]
 
-
         async def get_actions(self, request: Request) -> List[Action]:
             return [
                 Action(
-                    label = _("labeling"),
-                    icon = "ti ti-edit",
-                    name = "labeling"
+                    label=_("labeling"),
+                    icon="ti ti-edit",
+                    name="labeling",
+                    method=enums.Method.GET,
+                    ajax=False,
                 )
             ]
-
 
         async def get_bulk_actions(self, request: Request) -> List[Action]:
             return []

--- a/dashboard/resources.py
+++ b/dashboard/resources.py
@@ -82,6 +82,20 @@ class Dataset(Dropdown):
         filters = [filters.Search(name="task_type", label="Task Type")]
         fields = ["id", "task_type", "labeling_method", "release_time", "current_status"]
 
+
+        async def get_actions(self, request: Request) -> List[Action]:
+            return [
+                Action(
+                    label = _("labeling"),
+                    icon = "ti ti-edit",
+                    name = "labeling"
+                )
+            ]
+
+
+        async def get_bulk_actions(self, request: Request) -> List[Action]:
+            return []
+
     class Labeling(Link):
         """Label Studio Embedding"""
 

--- a/dashboard/routes.py
+++ b/dashboard/routes.py
@@ -106,3 +106,16 @@ async def stable1(request: Request):
     return templates.TemplateResponse(
         "stable/stable1.html", context={"request": request, "stable_1": table_1}
     )
+
+
+
+    # try:
+    #     return templates.TemplateResponse(
+    #         f"{resource}/update.html",
+    #         context=context,
+    #     )
+    # except TemplateNotFound:
+    #     return templates.TemplateResponse(
+    #         "update.html",
+    #         context=context,
+    #     )

--- a/dashboard/routes.py
+++ b/dashboard/routes.py
@@ -107,8 +107,6 @@ async def stable1(request: Request):
         "stable/stable1.html", context={"request": request, "stable_1": table_1}
     )
 
-
-
     # try:
     #     return templates.TemplateResponse(
     #         f"{resource}/update.html",

--- a/last/services/routes/resources.py
+++ b/last/services/routes/resources.py
@@ -279,8 +279,7 @@ async def bulk_delete(request: Request, ids: str, model: Model = Depends(get_mod
     return RedirectResponse(url=request.headers.get("referer"), status_code=HTTP_303_SEE_OTHER)
 
 
-
-@router.post("/{resource}/labeling/{pk}")
+@router.get("/{resource}/labeling/{pk}")
 async def labeling_view(
     request: Request,
     resource: str = Path(...),
@@ -292,8 +291,7 @@ async def labeling_view(
     obj = await model.get(pk=pk).prefetch_related(*model_resource.get_m2m_field())
     inputs = await model_resource.get_inputs(request, obj)
 
-    # TODO, @xiaomin, 这个请求进来了希望能够跳转到label.html
-    # 后续，就是将这个请求里面的参数传递给label.html，从而生成不同的标注页面形式
+    # TODO, @xiaomin, 将这个请求里面的参数传递给label.html，从而生成不同的标注页面形式
     context = {
         "request": request,
         "resources": resources,

--- a/last/services/routes/resources.py
+++ b/last/services/routes/resources.py
@@ -277,3 +277,42 @@ async def delete_view(request: Request, pk: str, model: Model = Depends(get_mode
 async def bulk_delete(request: Request, ids: str, model: Model = Depends(get_model)):
     await model.filter(pk__in=ids.split(",")).delete()
     return RedirectResponse(url=request.headers.get("referer"), status_code=HTTP_303_SEE_OTHER)
+
+
+
+@router.post("/{resource}/labeling/{pk}")
+async def labeling_view(
+    request: Request,
+    resource: str = Path(...),
+    pk: str = Path(...),
+    model_resource: ModelResource = Depends(get_model_resource),
+    resources=Depends(get_resources),
+    model: Type[Model] = Depends(get_model),
+):
+    obj = await model.get(pk=pk).prefetch_related(*model_resource.get_m2m_field())
+    inputs = await model_resource.get_inputs(request, obj)
+
+    # TODO, @xiaomin, 这个请求进来了希望能够跳转到label.html
+    # 后续，就是将这个请求里面的参数传递给label.html，从而生成不同的标注页面形式
+    context = {
+        "request": request,
+        "resources": resources,
+        "resource_label": model_resource.label,
+        "resource": resource,
+        "inputs": inputs,
+        "pk": pk,
+        "model_resource": model_resource,
+        "page_title": model_resource.page_title,
+        "page_pre_title": model_resource.page_pre_title,
+    }
+    print(context)
+    try:
+        return templates.TemplateResponse(
+            f"{resource}/label.html",
+            context=context,
+        )
+    except TemplateNotFound:
+        return templates.TemplateResponse(
+            "label.html",
+            context=context,
+        )

--- a/last/services/templates/label.html
+++ b/last/services/templates/label.html
@@ -1,0 +1,90 @@
+<!-- TODO @xiaomin，这个是标注页面采用的开源项目，您看看对不同的标注方式的用法，以及使用iframe嵌入到现有的前端页面中 -->
+
+<!DOCTYPE html>
+<html>
+
+<link href="https://unpkg.com/@heartexlabs/label-studio@1.4.0/build/static/css/main.css" rel="stylesheet">
+  <!-- <link href="https://unpkg.com/label-studio/build/static/css/main.css" rel="stylesheet"> -->
+  <!-- <link href="https://unpkg.com/label-studio@1.0.1/build/static/css/main.css" rel="stylesheet"> -->
+  <!-- Include the Label Studio library -->
+  <script src="https://unpkg.com/@heartexlabs/label-studio@1.4.0/build/static/js/main.js"></script>
+
+<body>
+  <div id="label-studio"></div>
+
+
+  <script>
+    const root = document.querySelector('#label-studio');
+    const labelStudio = new LabelStudio(root, {
+  config: `
+  <View>
+  <Labels name="label" toName="text">
+    <Label value="Person" background="red"/>
+    <Label value="Organization" background="darkorange"/>
+    <Label value="Fact" background="orange"/>
+    <Label value="Money" background="green"/>
+    <Label value="Date" background="darkblue"/>
+    <Label value="Time" background="blue"/>
+    <Label value="Ordinal" background="purple"/>
+    <Label value="Percent" background="#842"/>
+    <Label value="Product" background="#428"/>
+    <Label value="Language" background="#482"/>
+    <Label value="Location" background="rgba(0,0,0,0.8)"/>
+  </Labels>
+
+  <Text name="text" value="$text"/>
+</View>
+  `,
+  interfaces: [
+    "panel",
+    "update",
+    "submit",
+    "controls",
+    "side-column",
+    "skip",
+    "instruction",
+    "infobar",
+    "topbar",
+    "annotations:menu",
+    "annotations:add-new",
+    "annotations:delete",
+    "annotations:current",
+    "annotations:tabs",
+    "annotations:history",
+    "annotations:view-all",
+    "predictions:menu",
+    "predictions:tabs",
+    "auto-annotation",
+    "edit-history"
+  ],
+  user: {
+    pk: 1,
+    firstName: "James",
+    lastName: "Dean"
+  },
+  task: {
+    annotations: [],
+    predictions: [],
+    id: 1,
+    data: {
+      text: "https://htx-misc.s3.amazonaws.com/opensource/label-studio/examples/images/nick-owuor-astro-nic-visuals-wDifg5xc9Z4-unsplash.jpg"
+    }
+  }
+});
+
+labelStudio.on("labelStudioLoad", (LS) => {
+  // Perform an action when Label Studio is loaded
+  const c = LS.annotationStore.addAnnotation({
+    userGenerate: true
+  });
+  LS.annotationStore.selectAnnotation(c.id);
+  console.log("loading...")
+});
+
+labelStudio.on("submitAnnotation", (LS, annotation) => {
+  // Retrieve an annotation in JSON format
+  console.log(annotation.serializeAnnotation())
+});
+  </script>
+</body>
+</html>

--- a/last/services/templates/label.html
+++ b/last/services/templates/label.html
@@ -1,90 +1,148 @@
-<!-- TODO @xiaomin，这个是标注页面采用的开源项目，您看看对不同的标注方式的用法，以及使用iframe嵌入到现有的前端页面中 -->
-
-<!DOCTYPE html>
-<html>
-
+{% extends layout %}
+{% block page_body %}
 <link href="https://unpkg.com/@heartexlabs/label-studio@1.4.0/build/static/css/main.css" rel="stylesheet">
-  <!-- <link href="https://unpkg.com/label-studio/build/static/css/main.css" rel="stylesheet"> -->
-  <!-- <link href="https://unpkg.com/label-studio@1.0.1/build/static/css/main.css" rel="stylesheet"> -->
-  <!-- Include the Label Studio library -->
-  <script src="https://unpkg.com/@heartexlabs/label-studio@1.4.0/build/static/js/main.js"></script>
+<script src="https://unpkg.com/@heartexlabs/label-studio@1.4.0/build/static/js/main.js"></script>
 
 <body>
-  <div id="label-studio"></div>
 
+<div id="label-studio"></div>
 
-  <script>
-    const root = document.querySelector('#label-studio');
-    const labelStudio = new LabelStudio(root, {
-  config: `
-  <View>
-  <Labels name="label" toName="text">
-    <Label value="Person" background="red"/>
-    <Label value="Organization" background="darkorange"/>
-    <Label value="Fact" background="orange"/>
-    <Label value="Money" background="green"/>
-    <Label value="Date" background="darkblue"/>
-    <Label value="Time" background="blue"/>
-    <Label value="Ordinal" background="purple"/>
-    <Label value="Percent" background="#842"/>
-    <Label value="Product" background="#428"/>
-    <Label value="Language" background="#482"/>
-    <Label value="Location" background="rgba(0,0,0,0.8)"/>
-  </Labels>
+<script>
+    // TODO 后续填上label配置数据
+    function getLabelConfig() {
+        $.ajax({
+            url: '/',
+            method: 'get',
+            success: function (e) {
+                const tags = [
+                    {
+                        value: 'Person',
+                        background: 'red'
+                    },
+                    {
+                        value: 'Organization',
+                        background: 'darkorange'
+                    },
+                    {
+                        value: 'Fact',
+                        background: 'orange'
+                    },
+                    {
+                        value: 'Person',
+                        background: 'red'
+                    },
+                    {
+                        value: 'Money',
+                        background: 'green'
+                    },
+                    {
+                        value: 'Date',
+                        background: 'darkblue'
+                    },
+                    {
+                        value: 'Time',
+                        background: 'blue'
+                    },
+                    {
+                        value: 'Ordinal',
+                        background: 'purple'
+                    },
+                    {
+                        value: 'Percent',
+                        background: '#842'
+                    },
+                    {
+                        value: 'Product',
+                        background: '#428'
+                    },
+                    {
+                        value: 'Language',
+                        background: '#482'
+                    },
+                    {
+                        value: 'Location',
+                        background: 'rgba(0,0,0,0.8)'
+                    },
+                ]
+                const interfaces = [
+                        "panel",
+                        "update",
+                        "submit",
+                        "controls",
+                        "side-column",
+                        "skip",
+                        "instruction",
+                        "infobar",
+                        "topbar",
+                        "annotations:menu",
+                        "annotations:add-new",
+                        "annotations:delete",
+                        "annotations:current",
+                        "annotations:tabs",
+                        "annotations:history",
+                        "annotations:view-all",
+                        "predictions:menu",
+                        "predictions:tabs",
+                        "auto-annotation",
+                        "edit-history"
+                    ]
+                const text = "这是一段测试文本这是一段测试文本阖家安康手动滑稽卡号登记卡苍南县阿贾克斯发货单速发动机可塑性你记得康师傅你记得康师傅hi无回复和亢"
+                const labels = tags.map((tag) => {
+                    return `<Label value="${tag.value}" background="${tag.background}" />`
+                }).join('\n')
 
-  <Text name="text" value="$text"/>
-</View>
-  `,
-  interfaces: [
-    "panel",
-    "update",
-    "submit",
-    "controls",
-    "side-column",
-    "skip",
-    "instruction",
-    "infobar",
-    "topbar",
-    "annotations:menu",
-    "annotations:add-new",
-    "annotations:delete",
-    "annotations:current",
-    "annotations:tabs",
-    "annotations:history",
-    "annotations:view-all",
-    "predictions:menu",
-    "predictions:tabs",
-    "auto-annotation",
-    "edit-history"
-  ],
-  user: {
-    pk: 1,
-    firstName: "James",
-    lastName: "Dean"
-  },
-  task: {
-    annotations: [],
-    predictions: [],
-    id: 1,
-    data: {
-      text: "https://htx-misc.s3.amazonaws.com/opensource/label-studio/examples/images/nick-owuor-astro-nic-visuals-wDifg5xc9Z4-unsplash.jpg"
+                const tagView = `
+                    <View>
+                          <Labels name="label" toName="text">
+                          ${labels}
+                          </Labels>
+                          <Text name="text" value="$text"/>
+                    </View>
+                `
+
+                const root = document.querySelector('#label-studio');
+                const labelStudio = new LabelStudio(root, {
+                    config: tagView,
+                    interfaces: interfaces,
+                    user: {
+                        pk: 1,
+                        firstName: "James",
+                        lastName: "Dean"
+                    },
+                    task: {
+                        annotations: [],
+                        predictions: [],
+                        id: 1,
+                        data: {
+                            text: text
+                        }
+                    }
+                });
+
+                labelStudio.on("labelStudioLoad", (LS) => {
+                    // Perform an action when Label Studio is loaded
+                    const c = LS.annotationStore.addAnnotation({
+                        userGenerate: true
+                    });
+                    LS.annotationStore.selectAnnotation(c.id);
+                    console.log("loading...")
+                });
+
+                labelStudio.on("submitAnnotation", (LS, annotation) => {
+                    // Retrieve an annotation in JSON format
+                    console.log(annotation.serializeAnnotation())
+                });
+            }
+        })
     }
-  }
-});
 
-labelStudio.on("labelStudioLoad", (LS) => {
-  // Perform an action when Label Studio is loaded
-  const c = LS.annotationStore.addAnnotation({
-    userGenerate: true
-  });
-  LS.annotationStore.selectAnnotation(c.id);
-  console.log("loading...")
-});
+    // execute getLabelConfig when page load
+    window.onload = function () {
+        getLabelConfig();
+    }
 
-labelStudio.on("submitAnnotation", (LS, annotation) => {
-  // Retrieve an annotation in JSON format
-  console.log(annotation.serializeAnnotation())
-});
-  </script>
+
+</script>
 </body>
-</html>
+
+{% endblock %}


### PR DESCRIPTION
# Summary
本次pr是为了能够在数据标注页面，进行点击标注action，跳转到label studio页面

# Contents
- 增加了resource/labeling/pk的get请求路由函数
- 目前点击label这个action，直接跳转到label studio的template文件

# Next
- label studio的页面根据请求的数据跳转到不同的页面