### PR TITLE
add llm api test

### DIFF
--- a/last/client/call_llm.py
+++ b/last/client/call_llm.py
@@ -22,6 +22,7 @@ ALLES_CHAT_LLM = [
     "jieyue",
     "tigerbot",
     "mita",
+    "wuya",
 ]
 
 async def call_llm(model, temperature, system_prompt, human_prompt, **kwargs):

--- a/last/client/call_llm.py
+++ b/last/client/call_llm.py
@@ -102,32 +102,3 @@ async def generate(
         traceback.print_exc()
         raise ex
     return str(outputs)
-
-# async def _main():
-#     prompt = "How do you measure a year?"
-#     model = "tigerbot"
-#     system_prompt = None
-#     maximum_length = 1000
-#     temperature = 0.9 
-#     stop_sequence = None  
-#     top_p = 0.9
-#     frequence_penalty = 0.0
-#     presence_penalty = 0.0
-
-#     generated_text = await generate(
-#         prompt,
-#         model,
-#         system_prompt,
-#         maximum_length,
-#         temperature,
-#         stop_sequence,
-#         top_p,
-#         frequence_penalty,
-#         presence_penalty
-#     )
-
-#     print("生成的文本：", generated_text)
-
-# if __name__ == "__main__":
-
-#     asyncio.run(_main())

--- a/last/llms/alles_llm.py
+++ b/last/llms/alles_llm.py
@@ -6,6 +6,7 @@ from .model.http_puyu_api_model import PuyuAPILLMModel
 from .model.http_tigerbot_api_model import TigerbotAPILLMModel
 from .model.http_mita_api_model import MitaAPILLMModel
 from .model.http_jieyue_api_model import JieyueAPILLMModel
+from .model.http_wuya_api_model import WuyaAPILLMModel
 
 
 class AllesChatLLM(BaseModel):
@@ -41,6 +42,8 @@ class AllesChatLLM(BaseModel):
             api_key = os.environ["MITA_API_TOKEN"]
         elif self.model.lower().startswith("jieyue"):
             api_key = os.environ["JIEYUE_API_TOKEN"]
+        elif self.model.lower().startswith("wuya"):
+            api_key = os.environ["WUYA_API_TOKEN"]
         
         params = {
             "api_key": api_key,
@@ -67,6 +70,8 @@ class AllesChatLLM(BaseModel):
             model = MitaAPILLMModel(**params)
         elif self.model.lower() == "jieyue":
             model = JieyueAPILLMModel(**params)
+        elif self.model.lower() == "wuya":
+            model = WuyaAPILLMModel(**params)
         else:
             raise NotImplementedError()
 

--- a/last/llms/model/http_alles_api_model.py
+++ b/last/llms/model/http_alles_api_model.py
@@ -139,6 +139,9 @@ class AllesPalmAPILLMModel(HTTPAPILLMModel):
 
         
 class AllesClaudeAPILLMModel(HTTPAPILLMModel):
+    '''
+        Only support English
+    '''
     def __init__(self, api_key, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.url = "http://ecs.sv.us.alles-apin.openxlab.org.cn/v1/claude/v1/text/chat"
@@ -172,6 +175,9 @@ class AllesClaudeAPILLMModel(HTTPAPILLMModel):
 
         
 class AllesWenxinAPILLMModel(HTTPAPILLMModel):
+    '''
+        2023-10-27: This request is blocked by Alles-APIN due to auth failed.
+    '''
     def __init__(self, api_key, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.url = "https://openxlab.org.cn/gw/alles-apin/v1/baidu/v1/wenxinworkshop/chat"
@@ -183,7 +189,7 @@ class AllesWenxinAPILLMModel(HTTPAPILLMModel):
     async def generate(self, prompt, messages, *args, **kwargs):
         payload = {
             "messages": messages,
-            # "stream": False,
+            "stream": False,
             "user": "pjlab-alles-apin",
             # **kwargs,
         }

--- a/last/llms/model/http_mita_api_model.py
+++ b/last/llms/model/http_mita_api_model.py
@@ -74,11 +74,3 @@ class MitaAPILLMModel(HTTPAPILLMModel):
                 False,
                 'make order error:'+str(response)
             ) 
-
-
-# if __name__ == "__main__":
-#     hb = MitaAPILLMModel("47d10a183d75b780")
-#     resp = await hb.generate(prompt="", messages="妙手本手俗手")
-
-#     print(resp)
-#     print(hb.parse(resp))

--- a/last/llms/model/http_mita_api_model.py
+++ b/last/llms/model/http_mita_api_model.py
@@ -63,7 +63,7 @@ class MitaAPILLMModel(HTTPAPILLMModel):
 
                 data = self.get_result(response)
                 if data == False:
-                    time.sleep(5)
+                    time.sleep(1)
                 else:
                     return(
                         True,

--- a/last/llms/model/http_tigerbot_api_model.py
+++ b/last/llms/model/http_tigerbot_api_model.py
@@ -38,10 +38,3 @@ class TigerbotAPILLMModel(HTTPAPILLMModel):
             response["result"],
         )
 
-
-# if __name__ == "__main__":
-#     hb = TigerbotAPILLMModel("2dc003e5bd4ad9c66fbf05c4c9afd61922526dcfabe79d7673d66e1e51e901e9")
-#     resp = hb.generate(prompt="", messages="印度尼西亚的首都在哪里")
-
-#     print(resp)
-#     print(hb.parse(resp))

--- a/last/llms/model/http_wuya_api_model.py
+++ b/last/llms/model/http_wuya_api_model.py
@@ -1,0 +1,44 @@
+'''
+   Wuya API 没有chat功能 仅支持单条数据 
+'''
+import requests
+from .base_model import HTTPAPILLMModel
+
+        
+class WuyaAPILLMModel(HTTPAPILLMModel):
+    def __init__(self, api_key="", *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.url = "http://223.166.177.4:8091/chat/wuya"
+        self.api_key = api_key
+        self.headers = {
+            "Content-Type": "application/json",
+            # "Authorization": self.api_key,
+        }
+
+    async def generate(self, prompt, messages, *args, **kwargs):
+
+        payload = {
+            "query": messages[0]["content"],
+            "query_intention": "knowledge"
+        }
+
+
+        return requests.post(self.url, headers=self.headers, json=payload).json()
+
+    def parse(self, response):
+
+        try:
+            answer = response['wuya_output']
+            return (
+                True,
+                answer,
+            )
+        except Exception as e:
+            answer = None
+
+            return (
+                False,
+                e
+            )
+
+

--- a/tests/test_llm_api.py
+++ b/tests/test_llm_api.py
@@ -1,6 +1,6 @@
-'''
+"""
     Before running this test, please add the API key to the os.environ.
-'''
+"""
 import asyncio
 import os
 import time
@@ -39,7 +39,7 @@ async def generation_test(prompt, model):
         stop_sequence,
         top_p,
         frequence_penalty,
-        presence_penalty
+        presence_penalty,
     )
 
     return generated_text
@@ -47,9 +47,7 @@ async def generation_test(prompt, model):
 
 @unittest.skip("Need apikey")
 class TestLLMAPI(unittest.TestCase):
-
     def test_tigerbot_api(self):
-
         generated_text = asyncio.run(generation_test(prompt="中国的首都在哪里", model="tigerbot"))
         # print(generated_text)
         assert generated_text.startswith("北京")
@@ -78,13 +76,13 @@ class TestLLMAPI(unittest.TestCase):
         ]
 
         for model in ALLES_CHAT_LLM:
-
-            generated_text = asyncio.run(generation_test(prompt="Introduce your self!", model=model))
+            generated_text = asyncio.run(
+                generation_test(prompt="Introduce your self!", model=model)
+            )
             time.sleep(1)  # waiting for the release of resources
 
             assert generated_text is not None
 
 
-if __name__ == '__main__':
-
+if __name__ == "__main__":
     unittest.main()

--- a/tests/test_llm_api.py
+++ b/tests/test_llm_api.py
@@ -16,6 +16,7 @@ os.environ["PUYU_API_TOKEN"] = ""
 os.environ["TIGERBOT_API_TOKEN"] = ""
 os.environ["JIEYUE_API_TOKEN"] = ""
 os.environ["MITA_API_TOKEN"] = ""
+os.environ["WUYA_API_TOKEN"] = ""
 
 
 async def generation_test(prompt, model):
@@ -61,6 +62,12 @@ class TestLLMAPI(unittest.TestCase):
         generated_text = asyncio.run(generation_test(prompt="生日快乐", model="JieYue"))
         # 大小写都可以， eg. JIEYUE、jieyue
 
+        assert generated_text is not None
+
+    def test_wuya_api(self):
+        generated_text = asyncio.run(generation_test(prompt="投资目标是什么？", model="Wuya"))
+        # 大小写都可以， eg. wuya
+        print(generated_text)
         assert generated_text is not None
 
     def test_alles_chat_llm_api(self):

--- a/tests/test_llm_api.py
+++ b/tests/test_llm_api.py
@@ -66,8 +66,8 @@ class TestLLMAPI(unittest.TestCase):
 
     def test_wuya_api(self):
         generated_text = asyncio.run(generation_test(prompt="投资目标是什么？", model="Wuya"))
-        # 大小写都可以， eg. wuya
-        print(generated_text)
+        # 大小写都可以， eg. wuya, WUYA
+
         assert generated_text is not None
 
     def test_alles_chat_llm_api(self):

--- a/tests/test_llm_api.py
+++ b/tests/test_llm_api.py
@@ -5,7 +5,6 @@ import asyncio
 import os
 import time
 
-import pytest
 import unittest
 
 from last.client.call_llm import generate

--- a/tests/test_llm_api.py
+++ b/tests/test_llm_api.py
@@ -1,0 +1,93 @@
+'''
+    Before running this test, please add the API key to the os.environ.
+'''
+import asyncio
+import os
+import time
+
+import pytest
+import unittest
+
+from last.client.call_llm import generate
+
+# set the API key
+
+os.environ["ALLES_API_TOKEN"] = ""
+os.environ["PUYU_API_TOKEN"] = ""
+os.environ["TIGERBOT_API_TOKEN"] = ""
+os.environ["JIEYUE_API_TOKEN"] = ""
+os.environ["MITA_API_TOKEN"] = ""
+
+async def generation_test(prompt, model):
+    prompt = prompt
+    model = model
+    system_prompt = None
+    maximum_length = 1000
+    temperature = 0.9 
+    stop_sequence = None  
+    top_p = 0.9
+    frequence_penalty = 0.0
+    presence_penalty = 0.0
+
+    generated_text = await generate(
+        prompt,
+        model,
+        system_prompt,
+        maximum_length,
+        temperature,
+        stop_sequence,
+        top_p,
+        frequence_penalty,
+        presence_penalty
+    )
+
+    return generated_text
+
+@unittest.skip("Need apikey")
+class TestLLMAPI(unittest.TestCase):
+    
+    def test_tigerbot_api(self):
+
+        generated_text = asyncio.run(generation_test(prompt="中国的首都在哪里", model="tigerbot"))
+        # print(generated_text)
+        assert generated_text.startswith("北京")
+
+    def test_mita_api(self):
+        generated_text = asyncio.run(generation_test(prompt="生日快乐", model="Mita")) 
+        # 大小写都可以， eg. MITA、mita
+        # print(generated_text)
+        assert generated_text.startswith("生日快乐")
+
+    def test_jieyue_api(self):
+        generated_text = asyncio.run(generation_test(prompt="生日快乐", model="JieYue"))
+        # 大小写都可以， eg. JIEYUE、jieyue
+
+        assert generated_text is not None
+    
+    def test_alles_chat_llm_api(self):
+        ALLES_CHAT_LLM = [
+            "alles-minimax",
+            "alles-chatgpt",
+            "alles-gpt4",
+            "alles-palm",
+            "alles-claude",  # Only Support English
+            # "alles-wenxin",  # 这个暂时无法访问
+            "alles-spark",
+        ]
+
+
+
+        for model in ALLES_CHAT_LLM:
+
+            generated_text = asyncio.run(generation_test(prompt="Introduce your self!", model=model))
+            time.sleep(1)  # waiting for the release of resources
+
+            assert generated_text is not None
+
+            
+
+
+
+if __name__ == '__main__':
+    
+    unittest.main()

--- a/tests/test_llm_api.py
+++ b/tests/test_llm_api.py
@@ -18,13 +18,14 @@ os.environ["TIGERBOT_API_TOKEN"] = ""
 os.environ["JIEYUE_API_TOKEN"] = ""
 os.environ["MITA_API_TOKEN"] = ""
 
+
 async def generation_test(prompt, model):
     prompt = prompt
     model = model
     system_prompt = None
     maximum_length = 1000
-    temperature = 0.9 
-    stop_sequence = None  
+    temperature = 0.9
+    stop_sequence = None
     top_p = 0.9
     frequence_penalty = 0.0
     presence_penalty = 0.0
@@ -43,9 +44,10 @@ async def generation_test(prompt, model):
 
     return generated_text
 
+
 @unittest.skip("Need apikey")
 class TestLLMAPI(unittest.TestCase):
-    
+
     def test_tigerbot_api(self):
 
         generated_text = asyncio.run(generation_test(prompt="中国的首都在哪里", model="tigerbot"))
@@ -53,7 +55,7 @@ class TestLLMAPI(unittest.TestCase):
         assert generated_text.startswith("北京")
 
     def test_mita_api(self):
-        generated_text = asyncio.run(generation_test(prompt="生日快乐", model="Mita")) 
+        generated_text = asyncio.run(generation_test(prompt="生日快乐", model="Mita"))
         # 大小写都可以， eg. MITA、mita
         # print(generated_text)
         assert generated_text.startswith("生日快乐")
@@ -63,7 +65,7 @@ class TestLLMAPI(unittest.TestCase):
         # 大小写都可以， eg. JIEYUE、jieyue
 
         assert generated_text is not None
-    
+
     def test_alles_chat_llm_api(self):
         ALLES_CHAT_LLM = [
             "alles-minimax",
@@ -75,8 +77,6 @@ class TestLLMAPI(unittest.TestCase):
             "alles-spark",
         ]
 
-
-
         for model in ALLES_CHAT_LLM:
 
             generated_text = asyncio.run(generation_test(prompt="Introduce your self!", model=model))
@@ -84,10 +84,7 @@ class TestLLMAPI(unittest.TestCase):
 
             assert generated_text is not None
 
-            
-
-
 
 if __name__ == '__main__':
-    
+
     unittest.main()


### PR DESCRIPTION
## add tests for llm-api 
The following tests for the LLM API below have been written and passed:
- alles-minimax
- alles-chatgpt
- alles-gpt4
- alles-palm
- alles-claude  # Only Support English            
- alles-spark
- tigerbot
- jieyue
- mita

**alles-wenxin** is temporarily unavailable..