### PR TITLE
支持下载结果分表

### DIFF
--- a/dashboard/biz_models/labeling_model.py
+++ b/dashboard/biz_models/labeling_model.py
@@ -28,3 +28,4 @@ class LabelResult(Model):
     labeling_result = fields.CharField(max_length=10000, null=True, default=None)
     raw_labeling_result = fields.CharField(max_length=10000, null=True, default=None)
     risk_level = fields.CharField(max_length=200)
+    sheet_name = fields.CharField(max_length=200)

--- a/dashboard/biz_models/task_manage_model.py
+++ b/dashboard/biz_models/task_manage_model.py
@@ -13,3 +13,4 @@ class TaskManage(Model):
     assign_user = fields.CharField(max_length=255)
     audit_user = fields.CharField(max_length=255)
     risk_level = fields.CharField(max_length=255)
+    sheet_name_list = fields.CharField(max_length=2555)

--- a/dashboard/mock_data/mock_data.py
+++ b/dashboard/mock_data/mock_data.py
@@ -1,15 +1,16 @@
 # 标注相关重新初始化
-# from .mock_audit_data import create_audit_mock_data
-# from .mock_labeling_data import create_labeling_mock_data
-# from .mock_task import create_task
+from .mock_audit_data import create_audit_mock_data
+from .mock_labeling_data import create_labeling_mock_data
+
+# 系统必须的初始化
+from .mock_llms import create_mock_llms
+from .mock_risk import create_mock_risk
+from .mock_task import create_task
 
 # 数据相关重新初始化
 # from .clean_old import clean_old_record
 # from .mock_dataset import create_mock_dataset
 
-# 系统必须的初始化
-from .mock_llms import create_mock_llms
-from .mock_risk import create_mock_risk
 
 # 评测报告重新初始化
 # from .mock_report import create_mock_report
@@ -17,9 +18,9 @@ from .mock_risk import create_mock_risk
 
 
 async def create_mock_data():
-    # await create_labeling_mock_data()
-    # await create_task()
-    # await create_audit_mock_data()
+    await create_labeling_mock_data()
+    await create_task()
+    await create_audit_mock_data()
 
     await create_mock_risk()
     await create_mock_llms()

--- a/dashboard/templates/auditpage/revise.html
+++ b/dashboard/templates/auditpage/revise.html
@@ -771,12 +771,14 @@
 
 <button class="button" type="submit" onclick="submitForm()">更新</button>
 <script>
-    const audit_result =  getAuditResult();
-    if(audit_result == '确认'){
-        document.getElementById('confirm').checked=true;
-    }else{
-        document.getElementById('problem').checked=true;
-    }
+    getAuditResult().then((audit_result) =>{
+        console.log(audit_result);
+        if(audit_result == '确认'){
+            document.getElementById('confirm').checked=true;
+        }else{
+            document.getElementById('problem').checked=true;
+        }
+    });
 
 
     async function submitForm() {

--- a/dashboard/templates/taskmanage/download_page.html
+++ b/dashboard/templates/taskmanage/download_page.html
@@ -1,46 +1,29 @@
 {% extends layout %}
 {% block page_body %}
 <!-- 提供一个标注结果显示，以及下载的按钮 -->
+<style>
+    .table-responsive {
+  overflow: auto; /* 添加滚动条 */
+}
+</style>
+
+
 <script src="https://cdnjs.cloudflare.com/ajax/libs/xlsx/0.17.5/xlsx.full.min.js"></script>
 <div>
     <button id="download">下载Excel</button>
 </div>
 <div class="card">
+    <div class="table-responsive" id="tableContainer">
 
-    <div class="table-responsive">
-        <table class="table card-table table-vcenter text-nowrap datatable" id="myTable">
-            <thead>
-                <thead>
-                    <tr>
-                        <th>问题</th>
-                        <th>答案</th>
-                        <th>结果</th>
-                    </tr>
-                </thead>
-            </thead>
-            <tbody>
-
-
-                {% for item in label_result %}
-                <tr>
-                    <td>{{ item.question }}</td>
-                    <td>{{ item.answer }}</td>
-                    <td>{{ item.labeling_result }}</td>
-                </tr>
-                {% endfor %}
-
-            </tbody>
-        </table>
     </div>
 </div>
 
-<div>
-    <button id="download">下载Excel</button>
-</div>
-
 <script>
+    const decodedString = '{{sheet_name_list}}'.replace(/&#39;/g, "'");
+    const jsonString = decodedString.replace(/'/g, '"');
+    const sheetNameList = JSON.parse(jsonString);
     const downloadBtn = document.getElementById('download');
-    const dataTable = document.getElementById('myTable');
+    sheetNameList.forEach((sheetName)=>{create_table(sheetName)});
     // 状态标识
     downloadBtn.addEventListener('click', async () => {
         // 输入文件名
@@ -49,14 +32,80 @@
         //选择文件夹
         // 拼接完整路径
         const path = filename + '.xlsx';
-        // 生成工作表
-        const ws = XLSX.utils.table_to_sheet(dataTable);
+        // 生成工作表，使用循环的方式
         const wb = XLSX.utils.book_new();
-        XLSX.utils.book_append_sheet(wb, ws, 'Sheet1');
-        // 用完整路径保存文件
+        sheetNameList.forEach((sheetName) =>{
+            const dataTable = document.getElementById(sheetName);
+            const ws = XLSX.utils.table_to_sheet(dataTable);
+            XLSX.utils.book_append_sheet(wb, ws, sheetName);
+            // 用完整路径保存文件
+        });
         XLSX.writeFile(wb, path);
 
     });
+
+
+    // 创建一个新表
+    function create_table(sheetName){
+        var tableHtml = '<table class="table card-table table-vcenter text-nowrap datatable" id="' +sheetName + '">' +
+            '<thead>' +
+            '<tr>' +
+            '<th>问题</th>' +
+            '<th>答案</th>' +
+            '<th>风险等级</th>' +
+            '<th>标注者</th>' +
+            '</tr>' +
+            '</thead>' +
+            '<tbody>';
+        get_label_data(sheetName).then((data) =>{
+            for (var i = 0; i < data.length; i++) {
+                // {"test": {"风险程度": 2}}
+                label_user_dict = data[i]['labeling_result'];
+                if (label_user_dict == null){
+                    var label_user = null;
+                    var risk_level = null;
+                }else{
+                    var label_user = label_user_dict;
+                    // 删除字符串中的单引号
+                    var cleanedStr = label_user_dict.replace(/'/g, '"');
+                    // 解析字符串为对象
+                    var obj = JSON.parse(cleanedStr);
+                    // 获取对象的键
+                    var label_user = Object.keys(obj)[0];
+                    var risk_level = obj[label_user]['风险程度'];
+
+                };
+                tableHtml += '<tr>' +
+                    '<td>' + data[i].question + '</td>' +
+                    '<td>' + data[i].answer + '</td>' +
+                    '<td>' + risk_level + '</td>' +
+                    '<td>' + label_user + '</td>' +
+                    '</tr>';
+            }
+            tableHtml += '</tbody>' +
+                '</table>';
+
+        var tableContainer = document.getElementById('tableContainer');
+        var tempDiv = document.createElement('div');
+        tempDiv.innerHTML = tableHtml;
+        tableContainer.appendChild(tempDiv.firstChild);
+        });
+    }
+
+
+    async function get_label_data(sheet_name){
+        const rsp = await fetch('/admin/taskmanage/get_label_result', {
+            method: 'post',
+            body: JSON.stringify({"task_id": '{{task_id}}', "sheet_name": sheet_name}),
+            headers: {
+                'Content-Type': 'application/json'
+            }
+        })
+        return rsp.json();
+
+    }
+
+
 
 </script>
 {% endblock %}

--- a/dashboard/tools/statistic.py
+++ b/dashboard/tools/statistic.py
@@ -1,6 +1,8 @@
 import ast
 import html
 
+risk_level_dict = {"高度敏感": 1, "中度敏感": 2, "低度敏感": 3, "中性词": 4}
+
 
 def statistic_dataset(dataset_path):
     # 传入一个文件的路径，然后读取一系列的统计数据填充dataset
@@ -40,8 +42,10 @@ def convert_labelstudio_result_to_string(labeling_method, labeling_result_list, 
 
     elif _labeling_method == ["风险判别"]:
         if risk_level == "0级风险":
-            refine_result = {"0级风险": labeling_result_list[0]["value"]["choices"][0]}
-
+            # refine_result = {"0级风险": labeling_result_list[0]["value"]["choices"][0]}
+            refine_result = {
+                "风险程度": risk_level_dict[labeling_result_list[0]["value"]["choices"][0]]
+            }
         elif risk_level == "一级风险":
             refine_result = {"一级风险": labeling_result_list[0]["value"]["choices"][0]}
 
@@ -67,7 +71,7 @@ def convert_labelstudio_result_to_string(labeling_method, labeling_result_list, 
             refine_result = {}
             for labeling_result in labeling_result_list:
                 if labeling_result["from_name"] == "rating":
-                    refine_result["风险程度"] = labeling_result["value"]["choices"][0]
+                    refine_result["风险程度"] = risk_level_dict[labeling_result["value"]["choices"][0]]
                 else:
                     refine_result["一级风险"] = labeling_result["value"]["choices"][0]
 
@@ -75,7 +79,7 @@ def convert_labelstudio_result_to_string(labeling_method, labeling_result_list, 
             refine_result = {}
             for labeling_result in labeling_result_list:
                 if labeling_result["from_name"] == "rating":
-                    refine_result["风险程度"] = labeling_result["value"]["choices"][0]
+                    refine_result["风险程度"] = risk_level_dict[labeling_result["value"]["choices"][0]]
                 elif "grade_one" in labeling_result["from_name"]:
                     refine_result["一级风险"] = labeling_result["value"]["choices"][0]
                 else:
@@ -85,7 +89,7 @@ def convert_labelstudio_result_to_string(labeling_method, labeling_result_list, 
             refine_result = {}
             for labeling_result in labeling_result_list:
                 if labeling_result["from_name"] == "rating":
-                    refine_result["风险程度"] = labeling_result["value"]["choices"][0]
+                    refine_result["风险程度"] = risk_level_dict[labeling_result["value"]["choices"][0]]
                 elif "grade_one" in labeling_result["from_name"]:
                     refine_result["一级风险"] = labeling_result["value"]["choices"][0]
                 elif "grade_two" in labeling_result["from_name"]:

--- a/dashboard/utils/string_utils.py
+++ b/dashboard/utils/string_utils.py
@@ -14,7 +14,7 @@ def split_string_to_list(file_name, qa_records_stream):
 
 def split_csv_file(qa_records_stream):
     csv_data = pd.read_csv(BytesIO(qa_records_stream))
-    return [tuple(row) for row in csv_data.values]
+    return (["default"], [tuple(row) + ("default",) for row in csv_data.values])
 
 
 def split_xlsx_file(qa_records_stream):
@@ -24,7 +24,7 @@ def split_xlsx_file(qa_records_stream):
 
     for sheet in sheets:
         sheet_data = excel_data[sheet]
-        rows = [tuple(row) for row in sheet_data.values]
+        rows = [tuple(row) + (sheet,) for row in sheet_data.values]
         data = data + rows
 
-    return data
+    return (sheets, data)


### PR DESCRIPTION
- taskmanage，labelresult两个表增加一个字段，表明数据是哪个表，如果是csv就用default
- 下载结果风险等级用数字表示，拆分标注员列的结果
- 修复审核页面进行修改的时候数据没有改变的bug
