### PR TITLE
支持已经标注好的数据直接进入审核阶段

### DIFF
--- a/dashboard/biz_models/audit_model.py
+++ b/dashboard/biz_models/audit_model.py
@@ -20,3 +20,5 @@ class AuditResult(Model):
     answer = fields.CharField(max_length=25500)
     audit_result = fields.CharField(max_length=10000, null=True, default=None)
     sheet_name = fields.CharField(max_length=200)
+    model_label = fields.CharField(max_length=25500, null=True, default=None)
+    model_reason = fields.CharField(max_length=25500, null=True, default=None)

--- a/dashboard/templates/auditpage/audit.html
+++ b/dashboard/templates/auditpage/audit.html
@@ -32,7 +32,6 @@
 </style>
 <link href="https://unpkg.com/@heartexlabs/label-studio@1.4.0/build/static/css/main.css" rel="stylesheet">
 <script src="https://unpkg.com/@heartexlabs/label-studio@1.4.0/build/static/js/main.js"></script>
-
 <body>
 <div class="btn-group" role="group" style="width: 100px">
     {% for label in labels %}
@@ -72,52 +71,177 @@
     const task_id = urlParams.get('task_id');
     const risk_level = urlParams.get('risk_level');
     const labeling_method = urlParams.get('labeling_method').match(/'([^']+)'/)[1];
+    const configPromise = getLabelConfig();
+    const dataPromise = getLabelData();
+    const labelResultPromise = getLabelResult();
 
-    let tags = [];
-    let tagView = '';
-    let text = '';
-    let predictions = [];
-    let annotations = [];
-    const interfaces = [
-        "panel",
-        "controls",
-        "side-column",
-        "instruction",
-        "infobar",
-        "topbar",
-        "annotations:menu",
-        "annotations:add-new",
-        "annotations:delete",
-        "annotations:current",
-        "annotations:tabs",
-        "annotations:history",
-        "annotations:view-all",
-        "predictions:menu",
-        "predictions:tabs",
-        "auto-annotation",
-        "edit-history"
-    ]
+    function render_page () {
+        Promise.all([configPromise, dataPromise, labelResultPromise]).then(
+            res => {
+                let config
+                let data
+                let result
+                [config, data, result] = res
+                let answer = config.A
+                let question = config.Q
+                let model_label = config.model_label
+                let model_reason = config.model_reason
+                let text = question + "\n" + answer
+                let predictions
+                console.log(result)
+                if(model_reason != 'None'){
+                    text += ("\n" + model_reason) 
+                }
 
-    // 标注方法选择
-    var label_select;
+                let userID = config.user_id
+                if (data) {
+                    predictions = data.predictions;
+                }
+                const studio = document.querySelector('#label-studio')
+                
+                if (studio) {
+                    studio.remove()
+                }
+                const root = document.createElement('div');
+                root.id = 'label-studio'
+                document.getElementById('studio').append(root)
+                tagView = tag_view(question, answer, model_reason, risk_level, labeling_method)
+                const interfaces = [
+                    "panel",
+                    "controls",
+                    "side-column",
+                    "instruction",
+                    "infobar",
+                    "topbar",
+                    "annotations:menu",
+                    "annotations:add-new",
+                    "annotations:delete",
+                    "annotations:current",
+                    "annotations:tabs",
+                    "annotations:history",
+                    "annotations:view-all",
+                    "predictions:menu",
+                    "predictions:tabs",
+                    "auto-annotation",
+                    "edit-history"
+                ]
+                const labelStudio = new LabelStudio(root, {
+                    config: tagView,
+                    interfaces: interfaces,
+                    user: {
+                        pk: 1,
+                        firstName: userID,
+                        lastName: " "
+                    },
+                    task: {
+                        // https://labelstud.io/guide/export#Label-Studio-JSON-format-of-annotated-tasks
+                        annotations: [
+                            {
+                            result: JSON.parse(result.replace(/'/g, '"'))
+                            }
+                        ],
+                        predictions: predictions,
+                        id: 1,
+                        data: {
+                            text: text
+                        }
+                    }
+                })
+                
+                
+                labelStudio.on("labelStudioLoad", (LS) => {
+                    // Perform an action when Label Studio is loaded
+                    const c = LS.annotationStore.addAnnotation({
+                        userGenerate: true
+                    });
+                    LS.annotationStore.selectAnnotation(c.id);
+                    console.log("loading...")
+                })
+            }
+        )}
+    function select(name) {
+        document.getElementById(name).checked = true
+        render_page()
 
-    async function render_page () {
-        const config = await getLabelConfig();
-        const data = await getLabelData();
-        const result = await getLabelResult();
+    }
+    // TODO 初始态，标注方法列表的第一个
+    select(labeling_method)
+
+    $("input:radio[name='btn-radio-basic']").change((e) =>{
+        select(e.target.id)
+    });
 
 
-        if (config) {
-            answer = config.A;
-            question = config.Q;
-            userID = config.user_id;
-            text = question + "\n" + answer;
-            // const labels = tags.map((tag) => {
-            //     return `<Label value="${tag.value}" background="${tag.background}" />`
-            // }).join('\n')
-            // TODO answer现在假设只有一条，后面需要写一个js代码生成下面几段js代码
-            // 判断标注
-            const single_dialogs =
+    window.onload = function(){
+        render_page()
+        
+    }
+
+    async function getLabelData() {
+        const rsp = await fetch('/admin/lauditpage/audit/get_data', {
+            method: 'post',
+        })
+        return rsp.json();
+    }
+
+    async function getLabelConfig() {
+        const rsp = await fetch('/admin/auditpage/audit/get_config', {
+            method: 'post',
+            body: JSON.stringify({
+                "task_id": task_id, 
+                "question_id": question_id,
+                "labeling_method": labeling_method
+            }),
+            headers: {
+                'Content-Type': 'application/json'
+            }
+        })
+        return rsp.json();
+
+    }
+
+    async function getLabelResult(){
+        const rsp = await fetch('/admin/auditpage/audit/get_label_result', {
+            method: 'post',
+            body: JSON.stringify({
+                "task_id": task_id, 
+                "question_id": question_id,
+                "labeling_method": labeling_method
+            }),
+            headers: {
+                'Content-Type': 'application/json'
+            }
+        })
+        return rsp.json();
+    }
+
+
+    async function getNextPageConfig(){
+        const rsp = await fetch('/admin/auditpage/audit/next',{
+            method: 'post',
+            body: JSON.stringify({
+                "current_question_index": question_id - 1,
+                "task_id": task_id,
+                "labeling_method": '{{labels}}',
+                "risk_level": risk_level,
+            }),
+            headers: {
+                'Content-Type': 'application/json'
+                }
+        })
+        return rsp.json();
+    }
+
+
+    function tag_view(question, answer, model_reason, risk_level, label_select){
+        let extra_html
+        if (model_reason!='None'){
+            extra_html = `<p>${model_reason}</p>`
+        }
+        else{
+            extra_html = ``
+        }
+        const single_dialogs =
                 `<div style=\"max-width: 100%\">
                     <div style=\"clear: both\">
                         <div style=\"display: inline-block; background-color: #fff; border-radius: 12px 12px 12px 0; padding: 12px 18px; margin: 10px 0; max-width: 80%; color: rgba(18, 19, 22, 0.50)\">
@@ -131,6 +255,7 @@
                             <p>
                                 ${answer}
                             </p>
+                            ${extra_html}
                         </div>
                     </div>
                 </div>`;
@@ -151,6 +276,7 @@
                                 <p>
                                     ${answer}
                                 </p>
+                                ${extra_html}
                             </div>
                         </div>
                     </div>
@@ -173,6 +299,7 @@
                                 <p>
                                     ${answer}
                                 </p>
+                                ${extra_html}
                             </div>
                         </div>
                     </div>
@@ -193,6 +320,7 @@
                             <p>
                                 ${answer}
                             </p>
+                            ${extra_html}
                         </div>
                     </div>
                 </div>`;
@@ -212,6 +340,7 @@
                             <p>
                                 ${answer}
                             </p>
+                            ${extra_html}
                         </div>
                     </div>
                 </div>`;
@@ -661,118 +790,7 @@
             }else{
                 tagView = `<View>${label_list[label_selects.indexOf(label_select)]}</View>`
             }
-        }
-
-        if (data) {
-            annotations = data.annotations;
-            predictions = data.predictions;
-        }
-        const studio = document.querySelector('#label-studio')
-        if (studio) {
-            studio.remove()
-        }
-        const root = document.createElement('div');
-        root.id = 'label-studio'
-        document.getElementById('studio').append(root)
-        const labelStudio = new LabelStudio(root, {
-            config: tagView,
-            interfaces: interfaces,
-            user: {
-                pk: 1,
-                firstName: userID,
-                lastName: " "
-            },
-            task: {
-                // https://labelstud.io/guide/export#Label-Studio-JSON-format-of-annotated-tasks
-                annotations: [
-                    {
-                        result: JSON.parse(result.replace(/'/g, '"'))
-                    }
-                ],
-                predictions: predictions,
-                id: 1,
-                data: {
-                    text: text
-                }
-            }
-        });
-        labelStudio.on("labelStudioLoad", (LS) => {
-            // Perform an action when Label Studio is loaded
-            const c = LS.annotationStore.addAnnotation({
-                userGenerate: true
-            });
-            LS.annotationStore.selectAnnotation(c.id);
-            console.log("loading...")
-        });
-
-    }
-
-
-    function select(name) {
-        label_select = name
-        document.getElementById(name).checked = true
-        render_page()
-
-    }
-    // TODO 初始态，标注方法列表的第一个
-    select(labeling_method);
-
-    $("input:radio[name='btn-radio-basic']").change((e) =>{
-        select(e.target.id)
-    });
-
-
-    window.onload = function(){
-        render_page()
-    }
-
-
-
-    async function getLabelData() {
-        const rsp = await fetch('/admin/labelpage/labeling/get_data', {
-            method: 'post',
-        })
-        return rsp.json();
-    }
-
-    async function getLabelConfig() {
-        const rsp = await fetch('/admin/labelpage/labeling/get_config', {
-            method: 'post',
-            body: JSON.stringify({"task_id": task_id, "question_id": question_id}),
-            headers: {
-                'Content-Type': 'application/json'
-            }
-        })
-        return rsp.json();
-
-    }
-
-    async function getLabelResult(){
-        const rsp = await fetch('/admin/labelpage/labeling/get_label_result', {
-            method: 'post',
-            body: JSON.stringify({"task_id": task_id, "question_id": question_id}),
-            headers: {
-                'Content-Type': 'application/json'
-            }
-        })
-        return rsp.json();
-    }
-
-
-    async function getNextPageConfig(){
-        const rsp = await fetch('/admin/auditpage/audit/next',{
-            method: 'post',
-            body: JSON.stringify({
-                "current_question_index": question_id - 1,
-                "task_id": task_id,
-                "labeling_method": '{{labels}}',
-                "risk_level": risk_level,
-            }),
-            headers: {
-                'Content-Type': 'application/json'
-                }
-        })
-        return rsp.json();
+        return tagView
     }
 
 
@@ -811,6 +829,7 @@
         const auditResult = {}
         // 不知道为啥函数的调用没反应，这里将所有的选项给他放在一起
         const label_studio_option = document.querySelectorAll(".ant-form-inline")
+        console.log(label_studio_option)
         label_studio_option.forEach(function(sub_option, index){
             for (let i=0; i<sub_option.length; i++){
                 // 这段逻辑比较复杂，如果是多选框，就要用列表放，如果是单选框就直接放

--- a/dashboard/templates/auditpage/audit_brief_dataset.html
+++ b/dashboard/templates/auditpage/audit_brief_dataset.html
@@ -1,7 +1,17 @@
 {% extends layout %}
 {% block page_body %}
 
-
+<style>
+    table {
+      width: 100%;
+      table-layout: auto;
+    }
+  
+    td {
+      word-wrap: break-word;
+      white-space: normal;
+    }
+  </style>
 
     <div class="card">
 
@@ -13,9 +23,17 @@
 
                         <th>问题</th>
 
+                        <th>答案</th>
+
                         <th>当前状态</th>
 
+                        <th>模型标注</th>
+
+                        <th>模型原因</th>
+
                         <th>操作</th>
+
+                        
 
                 </tr>
                 </thead>
@@ -56,6 +74,7 @@
 
                 // 遍历数据并添加到表格中
                 data.forEach(function(item) {
+                    console.log(item)
                     const row = $('<tr></tr>');
 
                     const idCell = $('<td></td>').text(item.question_id);
@@ -64,9 +83,13 @@
                     const questionCell = $('<td></td>').text(item.question);
                     row.append(questionCell);
 
+                    const answerCell = $('<td></td>').text(item.answer);
+                    row.append(answerCell);
+
                     const statusCell = $('<td></td>').text(item.status);
                     row.append(statusCell);
-
+                    row.append(`<td>${item.model_label}</td>`)
+                    row.append(`<td>${item.model_reason}</td>`)
                     const actionCell = $('<td></td>');
                     const actionLink = $('<a></a>').text(item.action);
                     // 添加条件判断来设置不同的跳转链接和参数

--- a/dashboard/templates/labelpage/label.html
+++ b/dashboard/templates/labelpage/label.html
@@ -71,12 +71,16 @@
 
     // 标注方法选择
     var label_select;
+    const configPromise = getLabelConfig();
+    const dataPromise = getLabelData();
+    const nextPageConfigPromise = getNextPageConfig();
 
-    async function render_page () {
-        const config = await getLabelConfig();
-        const data = await getLabelData();
-        const nextPageConfig = await getNextPageConfig();
-        if (config) {
+    function render_page () {
+        Promise.all([configPromise, dataPromise, nextPageConfigPromise]).then(res => {
+            let config
+            let data
+            let nextPageConifg
+            [config, data, nextPageConfig] = res
             answer = config.A;
             question = config.Q;
             text = question + "\n" + answer;
@@ -619,7 +623,8 @@
             </View>
             `
             const label_list = [second_label, third_label, safe_label];
-            const label_selects = ['排序标注', '框选标注', '安全回答',];
+            const label_selects = ['排序标注', '框选标注', '安全回答',]
+            console.log(risk_level)
             if(risk_level != 'None'){
                 if (risk_level == '0级风险'){tagView = `<View>${risk_label_zero}</View>`}
                 if (risk_level == '一级风险'){tagView = `<View>${risk_label_one}</View>`}
@@ -631,90 +636,88 @@
             }else{
                 tagView = `<View>${label_list[label_selects.indexOf(label_select)]}</View>`
             }
-        }
-
-        if (data) {
-            annotations = data.annotations;
-            predictions = data.predictions;
-        }
-        const studio = document.querySelector('#label-studio')
-        if (studio) {
-            studio.remove()
-        }
-        const root = document.createElement('div');
-        root.id = 'label-studio'
-        document.getElementById('studio').append(root)
-        const labelStudio = new LabelStudio(root, {
-            config: tagView,
-            interfaces: interfaces,
-            user: {
-                pk: 1,
-                firstName: userID,
-                lastName: ' ',
-            },
-            task: {
-                annotations: annotations,
-                predictions: predictions,
-                id: 1,
-                data: {
-                    text: text
-                }
+            console.log(tagView)
+            if (data) {
+                annotations = data.annotations;
+                predictions = data.predictions;
             }
-        });
-
-        labelStudio.on("labelStudioLoad", (LS) => {
-            // Perform an action when Label Studio is loaded
-            const c = LS.annotationStore.addAnnotation({
-                userGenerate: true
-            });
-            LS.annotationStore.selectAnnotation(c.id);
-            console.log("loading...")
-        });
-
-        labelStudio.on("submitAnnotation", (LS, annotation) => {
-            // Retrieve an annotation in JSON format
-            // 这个地方对三级标注进行判断
-            $.ajax({
-                url: '/admin/labelpage/labeling/{item}/submit',
-                method: 'post',
-                data: JSON.stringify({
-                    "annotation": annotation.serializeAnnotation(),
-                    "question_id": question_id,
-                    "task_id": task_id,
-                    "labeling_method": urlParams.get('labeling_method'),
-                    "risk_level": risk_level,
-                    }),
-                success: function (e) {
-                    // 如果成功，就对后端发送next请求？并且将当前的用户id发送回去
-                    // 访问一下后端的一个标注函数
-                    console.log(nextPageConfig);
-                    if (nextPageConfig.question_id == 'null'){
-                        const briefDataUrl = '/admin/labelpage/display/' + '{{task_pk_value}}';
-                        window.location.href = briefDataUrl;
-                    }else{
-                        const labelingUrl = '/admin/labelpage/labeling/' + nextPageConfig.task_id + '_' + nextPageConfig.question_id;
-                        // 在链接中添加参数
-                        const params = {
-                            question_id: nextPageConfig.question_id,
-                            task_id: nextPageConfig.task_id,
-                            labeling_method: urlParams.get('labeling_method'),
-                            task_pk_value: '{{task_pk_value}}',
-                            risk_level: nextPageConfig.risk_level,
-                            // 添加其他参数
-                        };
-                        const queryString = $.param(params);
-                        const urlWithParams = labelingUrl + '?' + queryString;
-                        window.location.href=urlWithParams;
-                    }
+            const studio = document.querySelector('#label-studio')
+            if (studio) {
+                studio.remove()
+            }
+            const root = document.createElement('div');
+            root.id = 'label-studio'
+            document.getElementById('studio').append(root)
+            const labelStudio = new LabelStudio(root, {
+                config: tagView,
+                interfaces: interfaces,
+                user: {
+                    pk: 1,
+                    firstName: userID,
+                    lastName: ' ',
                 },
-                error: function (e) {
-                    history.back();
+                task: {
+                    annotations: annotations,
+                    predictions: predictions,
+                    id: 1,
+                    data: {
+                        text: text
+                    }
                 }
+            });
+
+            labelStudio.on("labelStudioLoad", (LS) => {
+                // Perform an action when Label Studio is loaded
+                const c = LS.annotationStore.addAnnotation({
+                    userGenerate: true
+                });
+                LS.annotationStore.selectAnnotation(c.id);
+                console.log("loading...")
+            });
+
+            labelStudio.on("submitAnnotation", (LS, annotation) => {
+                // Retrieve an annotation in JSON format
+                // 这个地方对三级标注进行判断
+                $.ajax({
+                    url: '/admin/labelpage/labeling/{item}/submit',
+                    method: 'post',
+                    data: JSON.stringify({
+                        "annotation": annotation.serializeAnnotation(),
+                        "question_id": question_id,
+                        "task_id": task_id,
+                        "labeling_method": urlParams.get('labeling_method'),
+                        "risk_level": risk_level,
+                        }),
+                    success: function (e) {
+                        // 如果成功，就对后端发送next请求？并且将当前的用户id发送回去
+                        // 访问一下后端的一个标注函数
+                        console.log(nextPageConfig);
+                        if (nextPageConfig.question_id == 'null'){
+                            const briefDataUrl = '/admin/labelpage/display/' + '{{task_pk_value}}';
+                            window.location.href = briefDataUrl;
+                        }else{
+                            const labelingUrl = '/admin/labelpage/labeling/' + nextPageConfig.task_id + '_' + nextPageConfig.question_id;
+                            // 在链接中添加参数
+                            const params = {
+                                question_id: nextPageConfig.question_id,
+                                task_id: nextPageConfig.task_id,
+                                labeling_method: urlParams.get('labeling_method'),
+                                task_pk_value: '{{task_pk_value}}',
+                                risk_level: nextPageConfig.risk_level,
+                                // 添加其他参数
+                            };
+                            const queryString = $.param(params);
+                            const urlWithParams = labelingUrl + '?' + queryString;
+                            window.location.href=urlWithParams;
+                        }
+                    },
+                    error: function (e) {
+                        history.back();
+                    }
+                })
             })
         })
-        console.log(labelStudio)
     }
-
     function select(name) {
         label_select = name
         document.getElementById(name).checked = true

--- a/dashboard/templates/taskmanage/create_model_labeled_task.html
+++ b/dashboard/templates/taskmanage/create_model_labeled_task.html
@@ -1,0 +1,218 @@
+{% extends layout %}
+{% block page_body %}
+<style>
+    .form-table {
+        display: flex;
+        flex-direction: column;
+    }
+
+    .text {
+        float: left;
+        width: 50%;
+        padding-right: 20px;
+    }
+
+    table {
+        float: left;
+        border-collapse: collapse;
+        width: 300px;
+    }
+
+    th,
+    td {
+        padding: 8px;
+        text-align: left;
+        border: 1px solid #ccc;
+    }
+
+    th {
+        background-color: #f2f2f2;
+    }
+
+    .button {
+        width: 80px;
+        /* 设置按钮宽度为80px */
+        height: 40px;
+        padding: 10px;
+        font-size: 16px;
+    }
+
+    .loading-text {
+      position: fixed;
+      top: 50%;
+      left: 50%;
+      transform: translate(-50%, -50%);
+      font-size: 24px;
+      font-weight: bold;
+      animation: jump 1s infinite;
+    }
+
+    @keyframes jump {
+      0% { transform: translate(-50%, -50%) translateY(0); }
+      50% { transform: translate(-50%, -50%) translateY(-10px); }
+      100% { transform: translate(-50%, -50%) translateY(0); }
+    }
+
+</style>
+
+
+<div class="form-group">
+    <label for="file">标注数据集</label>
+    <input type="file" id="file" name="file" value="请选择文件">
+</div>
+
+
+<div class="form-date">
+    <div class="form-group">
+        <label for="deadline">截止时间：</label>
+        <input type="datetime-local" id="deadline" name="deadline" value="请输入时间">
+    </div>
+</div>
+
+
+<div class="form-table">
+    <div class="text">
+        <span>审核任务分配</span>
+    </div>
+    <table id="auditTable" <thead>
+        <tr>
+            <th>审核员</th>
+            <th>题目数量百分比（%）</th>
+            <th>操作</th>
+        </tr>
+        </thead>
+        <tbody>
+
+        </tbody>
+    </table>
+</div>
+<div>
+    <label for="auditUserName">审核员：</label>
+    <select id="auditUserName">
+        <option value="">请选择审核员</option>
+    </select>
+    <label for="quantity">题目数量百分比：</label>
+    <input type="number" id="auditQuantity" value="百分比">
+    <button onclick="addAuditRow()">添加</button>
+</div>
+
+<button class="button" type="submit" id="submitButton" onclick="submitForm()">提交</button>
+<div id="loading-text" class="loading-text" style="display: none;">任务正在创建中，请稍后。。。</div>
+
+    <script>
+        async function fetchUserOptions() {
+            // 调用 task/user_ge 接口获取标注员列表
+            var userList = await getUserList();
+            //   var userList = ['标注员A', '标注员B', '标注员C'];
+            // 这个是审核表
+            var dropdown = document.getElementById('auditUserName');
+            dropdown.innerHTML = '<option value="">请选择审核员</option>';
+            userList.forEach(function (user) {
+                var option = document.createElement('option');
+                option.value = user;
+                option.text = user;
+                dropdown.appendChild(option);
+            });
+        }
+
+        function addAuditRow() {
+            var table = document.getElementById('auditTable');
+            var username = document.getElementById('auditUserName').value;
+            var quantity = document.getElementById('auditQuantity').value;
+            if (username && quantity) {
+                var row = table.insertRow(-1);
+                var cell1 = row.insertCell(0);
+                var cell2 = row.insertCell(1);
+                var cell3 = row.insertCell(2);
+
+                cell1.innerHTML = username;
+                cell2.innerHTML = quantity;
+                cell3.innerHTML = '<button onclick="deleteRow(this)">删除</button>';
+
+                // 清空输入框
+                document.getElementById('auditUserName').value = '';
+                document.getElementById('auditQuantity').value = '';
+            }
+        }
+
+        // 删除行
+        function deleteRow(btn) {
+            var row = btn.parentNode.parentNode;
+            row.parentNode.removeChild(row);
+        }
+
+        // 页面加载时获取下拉框选项值
+        window.onload = function () {
+            fetchUserOptions();
+        };
+
+        function submitForm() {
+            // 创建表单对象
+            var isSubmitted = false;
+            var formData = new FormData();
+            var fileInput = document.getElementById('file');
+            var file = $('#file')[0].files[0];
+            var fileName = file.name; // 获取文件的路径
+            var deadlineInput = document.getElementById('deadline');
+            var deadline = deadlineInput.value;
+        
+            // 审计任务分配表
+            var auditTable = document.getElementById('auditTable');
+            var auditAssignments = [];
+            for (var i = 1; i < auditTable.rows.length; i++) {
+                var cells = auditTable.rows[i].cells;
+                var auditor = cells[0].textContent;
+                var taskCount = cells[1].textContent;
+                auditAssignments.push({ auditor: auditor, taskCount: taskCount });
+            }
+            // 确保taskAssignments，auditAssignments中taskCount之和为100
+            var auditTotal = 0;
+            for (var assignment of auditAssignments) {
+                auditTotal += Number(assignment.taskCount);
+            }
+                if (auditTotal != 100) {
+                    alert("审核分配之和必须为100");
+                } else {
+                    formData.append('fileName', fileName);
+                    formData.append('deadline', deadline);
+                    formData.append('file', file);
+                    formData.append('auditAssignments', JSON.stringify(auditAssignments));
+                    // 调用回调函数，将数据传递给它进行处理
+                    // 使用 $.ajax 发送数据到特定的 URL
+                    if (!isSubmitted) {
+                        isSubmitted = true;
+                        $('#submitButton').prop('disabled', true);
+                        var loadingText = document.getElementById('loading-text');
+                        loadingText.style.display = 'block';
+                        $.ajax({
+                            type: 'POST',
+                            url: '/admin/taskmanage/create_model_task_callback',
+                            data: formData,
+                            processData: false,
+                            contentType: false,
+                            success: function (response) {
+                                // 请求成功的处理
+                                loadingText.style.display = 'none';
+                                // history.back();
+                                location.href = '/admin/taskmanage/list';
+                            },
+                            error: function (error) {
+                                // 请求失败的处理
+                                alert("当前只接受csv文件或者xlsx文件");
+                            }
+                        });
+                    };
+                };
+        }
+
+
+        async function getUserList() {
+            const rsp = await fetch('/admin/taskmanage/get_user_list', {
+                method: 'get',
+            })
+            return rsp.json();
+        }
+
+    </script>
+    </body>
+{% endblock %}

--- a/dashboard/templates/taskmanage/create_task.html
+++ b/dashboard/templates/taskmanage/create_task.html
@@ -90,7 +90,7 @@
             <label><input type="checkbox" id="risk-level">判断风险类别</label>
 
             <select id="risk-grade">
-                <option value="default" disabled selected>请选择风险类型</option>
+                <option value="0级风险" disabled selected>请选择风险类型</option>
                 <option value="一级风险" disabled>一级风险类型</option>
                 <option value="二级风险" disabled>二级风险类型</option>
                 <option value="三级风险" disabled>三级风险类型</option>

--- a/dashboard/templates/taskmanage/download_page.html
+++ b/dashboard/templates/taskmanage/download_page.html
@@ -28,6 +28,16 @@
     .tab-active{
         color:red
     }
+
+    table {
+      width: 100%;
+      table-layout: auto;
+    }
+  
+    td {
+      word-wrap: break-word;
+      white-space: normal;
+    }
 </style>
 
 
@@ -90,23 +100,26 @@
             '<tr>' +
             '<th>问题</th>' +
             '<th>答案</th>' +
-            '<th>风险等级</th>' +
+            '<th>标注结果</th>' +
             '<th>标注者</th>' +
-            '<th>风险等级</th>' +
+            '<th>审核结果</th>' +
             '<th>审核者</th>' +
+            '<th>模型评价</th>' +
+            '<th>模型原因</th>' +
             '</tr>' +
             '</thead>' +
-            '<tbody>';
+            '<tbody>'
+        
+
         get_label_data(sheetName).then((data) =>{
             for (var i = 0; i < data.length; i++) {
-                // {"test": {"风险程度": 2}}
                 label_user_dict = data[i]['labeling_result']
                 audit_user_dict = data[i]['audit_result']
                 let label_user
                 let risk_level
                 let audit_user
                 let audit_risk_level
-                if (label_user_dict == null){
+                if (label_user_dict == null || label_user_dict == 'None'){
                     label_user = null;
                     risk_level = null;
                 }else{
@@ -122,14 +135,18 @@
                 if (audit_user_dict == null){
                     audit_user = null;
                     audit_risk_level = null;
+                    if(data[i].model_label!='None'){
+                        audit_user = '自动审核'
+                        audit_risk_level = data[i].model_label
+                    }
                 } else{
                     audit_user = audit_user_dict
                     let cleanedStr = audit_user_dict.replace(/'/g, '"');
                     // 解析字符串为对象
-                    let obj = JSON.parse(cleanedStr);
+                    let obj = JSON.parse(cleanedStr)
                     // 获取对象的键
-                    audit_user = Object.keys(obj)[0];
-                    audit_risk_level = obj[label_user]['风险程度'];
+                    audit_user = Object.keys(obj)[0]
+                    audit_risk_level = obj[audit_user]['风险程度'];
                 }
 
                 tableHtml += '<tr>' +
@@ -139,6 +156,8 @@
                     '<td>' + label_user + '</td>' +
                     '<td>' + audit_risk_level + '</td>' +
                     '<td>' + audit_user + '</td>' +
+                    '<td>' + data[i].model_label + '</td>'+ 
+                    '<td>' + data[i].model_reason + '</td>' +
                     '</tr>';
             }
             tableHtml += '</tbody>' +

--- a/dashboard/tools/statistic.py
+++ b/dashboard/tools/statistic.py
@@ -118,7 +118,11 @@ def convert_table_to_csv(table):
 
 
 def convert_audit_data(labeling_method, audit_result, risk_level):
-    if labeling_method == "判断标注":
+    if labeling_method == "Model":
+        if risk_level == "0级风险":
+            refine_result = {"风险程度": risk_level_dict[audit_result["0"]]}
+
+    elif labeling_method == "判断标注":
         # TODO，这个函数需要修改
         refine_result = audit_result["0"]
 


### PR DESCRIPTION
- 修改数据库，labelResult, AuditResult两个表，都增加了model_label, model_reason两个字段
- 修改了brief_audit_dataset页面，表格文字自适应，增加模型标注和模型原因两个字段
- 修改了download页面，增加了模型标注和模型原因两个字段
- 下载的时候如果数据没有审核，模型有标注结果，就将模型的标注结果复制给审核结果，将审核人变成自动审核