### PR TITLE
add midu & ruyichat api

### DIFF
--- a/.env
+++ b/.env
@@ -22,3 +22,5 @@ MINIMAX_API_TOKEN='{"group_id": "xxx", "api_key": "xxx"}'
 SHANGTANG_API_TOKEN='{"ak": "xxx", "sk": "xxx"}'
 WARRENQ_API_TOKEN='{"AppKey":"xxx", "accountName": "xxx", "mobile": "xxx", "sign": "xxx", "AppSecret": "xxxxxx"}'
 GIANTGPT_API_TOKEN=""
+RUYIGPT_API_TOKEN='{"source": "xxx", "version": "xxx", "mc": "xxx", "uid": "xxx", "devid": "xxx", "verifyCode": "xxx"}'
+MIDU_API_TOKEN=""

--- a/dashboard/mock_data/mock_llms.py
+++ b/dashboard/mock_data/mock_llms.py
@@ -380,6 +380,70 @@ async def create_mock_llms():
     )
 
     await ModelInfo.create(
+        name="ruyichat",
+        endpoint="ruyichat",
+        access_key="None",
+        secret_key="None",
+        model_type="聊天机器人、自然语言处理助手",
+        version="未知",
+        base_model="未知",
+        parameter_volume="未知",
+        pretraining_info="未知",
+        finetuning_info="未知",
+        alignment_info="未知",
+        model_org="None",
+        auth_status=False,
+    )
+
+    await ModelInfo.create(
+        name="midu",
+        endpoint="midu",
+        access_key="None",
+        secret_key="None",
+        model_type="聊天机器人、自然语言处理助手",
+        version="未知",
+        base_model="未知",
+        parameter_volume="未知",
+        pretraining_info="未知",
+        finetuning_info="未知",
+        alignment_info="未知",
+        model_org="None",
+        auth_status=False,
+    )
+
+    await ModelInfo.create(
+        name="warrenq",
+        endpoint="warrenq",
+        access_key="None",
+        secret_key="None",
+        model_type="聊天机器人、自然语言处理助手",
+        version="未知",
+        base_model="未知",
+        parameter_volume="未知",
+        pretraining_info="未知",
+        finetuning_info="未知",
+        alignment_info="未知",
+        model_org="None",
+        auth_status=False,
+    )
+
+    await ModelInfo.create(
+        name="giantgpt",
+        endpoint="giantgpt",
+        access_key="None",
+        secret_key="None",
+        model_type="聊天机器人、自然语言处理助手",
+        version="未知",
+        base_model="未知",
+        parameter_volume="未知",
+        pretraining_info="未知",
+        finetuning_info="未知",
+        alignment_info="未知",
+        model_org="None",
+        auth_status=False,
+    )
+
+    await ModelInfo.create(
         name="xiaohongshu",
         endpoint="xiaohongshu",
         access_key="None",

--- a/last/client/call_llm.py
+++ b/last/client/call_llm.py
@@ -38,6 +38,8 @@ ALLES_CHAT_LLM = [
     "erniebot",
     "warrenq",
     "giantgpt",
+    "ruyigpt",
+    "midu",
 ]
 
 

--- a/last/llms/alles_llm.py
+++ b/last/llms/alles_llm.py
@@ -31,6 +31,8 @@ from .model.http_minimax_api_model import MinimaxAPILLMModel
 from .model.http_ERNIEBot_api_model import ERNIEBOTAPILLMModel
 from .model.http_warrenq_api_model import WarrenQAPILLMModel
 from .model.http_giantgpt_api_model import GiantgptAPILLMModel
+from .model.http_ruyichat_api_model import RuyichatAPILLMModel
+from .model.http_midu_api_model import MiduAPILLMModel
 
 
 class AllesChatLLM(BaseModel):
@@ -98,6 +100,10 @@ class AllesChatLLM(BaseModel):
             api_key = os.environ["WARRENQ_API_TOKEN"]
         elif self.model.lower().startswith("giantgpt"):
             api_key = os.environ["GIANTGPT_API_TOKEN"]
+        elif self.model.lower().startswith("ruyigpt"):
+            api_key = os.environ["RUYIGPT_API_TOKEN"]
+        elif self.model.lower().startswith("midu"):
+            api_key = os.environ["MIDU_API_TOKEN"]
 
         params = {
             "api_key": api_key,
@@ -156,6 +162,10 @@ class AllesChatLLM(BaseModel):
             model = WarrenQAPILLMModel(**params)
         elif self.model.lower() == "giantgpt":
             model = GiantgptAPILLMModel(**params)
+        elif self.model.lower().startswith("ruyigpt"):
+            model = RuyichatAPILLMModel(**params)
+        elif self.model.lower().startswith("midu"):
+            model = MiduAPILLMModel(**params)
         else:
             raise NotImplementedError()
 

--- a/last/llms/model/http_midu_api_model.py
+++ b/last/llms/model/http_midu_api_model.py
@@ -1,0 +1,42 @@
+"""
+   蜜度 Midu API
+"""
+import json
+from .base_model import HTTPAPILLMModel
+
+
+class MiduAPILLMModel(HTTPAPILLMModel):
+    def __init__(self, api_key, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.url = "https://www.midu.com/miduwgt/gateway/api/values/question"
+        self.api_key = api_key
+        self.headers = {
+            "Content-Type": "application/json;charset=UTF-8",
+            "Authorization": self.api_key,
+        }
+
+    async def generate(self, prompt, messages, *args, **kwargs):
+        payload = {
+            "model": "midu-michao",
+            "query": messages[-1]["content"],
+            **kwargs,
+        }
+        # len(payload["query"]) < 4096
+        try:
+            resp = await self.async_post(
+                self.url, headers=self.headers, data=json.dumps(payload)
+            )
+            
+        except Exception as e:
+ 
+            return e
+        return resp
+
+    def parse(self, response):
+        if "code" not in response:
+            return (False, "Midu Api Error")
+        
+        if response["code"] != "0000":
+            return (False, response["message"])
+        
+        return (True, response["data"])

--- a/last/llms/model/http_ruyichat_api_model.py
+++ b/last/llms/model/http_ruyichat_api_model.py
@@ -1,0 +1,59 @@
+"""
+   昶甘信息 ruyichat API 
+"""
+import re
+import json
+from .base_model import HTTPAPILLMModel
+
+
+class RuyichatAPILLMModel(HTTPAPILLMModel):
+    def __init__(self, api_key, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        params: dict = json.loads(api_key)
+        # params ---------------------------
+        self.source = params["source"]
+        self.version = params["version"]
+        self.mc = params["mc"]
+        self.uid = params["uid"]
+        self.devid = params["devid"]
+        self.verifyCode = params["verifyCode"]
+        # params ---------------------------
+        self.url = f"https://gptapi.ruyichat.com/v6/questionanswer?source={self.source}&version={self.version}&mc={self.mc}&uid={self.uid}&devid={self.devid}&verifyCode={self.verifyCode}"
+        self.headers = {
+            "Content-Type": "application/json",
+        }
+
+    async def generate(self, prompt, messages, *args, **kwargs):
+        payload = {
+            "input": messages[-1]["content"],
+            "conversation_id": f"{self.uid}_{self.devid}_20231225",
+            **kwargs,
+        }
+        try:
+            resp = await self.async_post(
+                self.url, headers=self.headers, data=json.dumps(payload)
+            )
+            
+        except Exception as e:
+ 
+            return e
+        return resp
+
+    def parse(self, response):
+        p_status = re.compile('{"data":.*?,"info":"(.*?)","status":(.*?)}')
+        p_data = re.compile('{"data":{"id":".*?","content":"(.*?)"},"info":"(.*?)","status":(.*?)}')
+        status_data_list = re.findall(p_status, response)
+        # status_data_list =[('登录信息无效', '0')]
+        for item in status_data_list:
+            if int(item[1]) != 1:
+                return (False, item[0])
+        # 输出
+        data_list = re.findall(p_data, response)
+        # data_list = [('中', 'success', '1'), ('的', 'success', '1')]
+        tmp_str = ""
+        
+        for item in data_list:
+            if int(item[2]) != 1:
+                return (False, "error")
+            tmp_str += item[0]
+        return (True, tmp_str)

--- a/last/llms/model/http_xiaohui_api_model.py
+++ b/last/llms/model/http_xiaohui_api_model.py
@@ -1,0 +1,57 @@
+"""
+   大智慧惠问 xiaohui API
+"""
+import json
+# from .base_model import HTTPAPILLMModel
+
+
+# class XiaohuiAPILLMModel(HTTPAPILLMModel):
+#     def __init__(self, api_key, *args, **kwargs):
+#         super().__init__(*args, **kwargs)
+#         self.url = "https://api-bz7ic07j.tigerbot.com/v1/chat/completions"
+#         self.api_key = api_key
+#         self.headers = {
+#             "Content-Type": "application/json",
+#             "Authorization": "Bearer " + self.api_key,
+#         }
+
+#     async def generate(self, prompt, messages, *args, **kwargs):
+#         payload = {
+#             "model": "tigerbot-70b-chat",
+#             "query": messages[-1]["content"],
+#             **kwargs,
+#         }
+#         try:
+#             resp = await self.async_post(
+#                 self.url, headers=self.headers, data=json.dumps(payload)
+#             )
+            
+#         except Exception as e:
+ 
+#             return e
+#         return resp
+
+#     def parse(self, response):
+#         if "error" in response:
+#             return (False, response["error"]["message"])
+
+#         return (
+#             True,
+#             response["result"],
+#         )
+
+# import requests
+
+# url = "https://xiaohuiapi1.dzh.com.cn/xiaohui/answer?q=&token="
+# headers = {
+#     "Content-Type": "application/json",
+# }
+# resp = requests.post(url=url, headers=headers, data=json.dumps({}))
+
+# print(resp.json())
+# resp_get = requests.get(
+#     url="https://xiaohuiapi1.dzh.com.cn//xiaohui/search?q=&token=",
+#     headers=headers,
+#     data=json.dumps({}),
+# )
+# print(resp_get.json())

--- a/tests/test_llm_api.py
+++ b/tests/test_llm_api.py
@@ -38,6 +38,16 @@ class TestLLMAPI(unittest.TestCase):
         print("tigerbot", generated_text)
         assert generated_text.startswith("北京")
 
+    def test_ruyigpt_api(self):
+        generated_text = asyncio.run(generation_test(prompt="中国的首都在哪里", model="ruyigpt"))
+        print("ruyigpt", generated_text)
+        assert generated_text is not None
+
+    def test_midu_api(self):
+        generated_text = asyncio.run(generation_test(prompt="中国的首都在哪里", model="midu"))
+        print("midu", generated_text)
+        assert generated_text is not None
+
     def test_soul_api(self):
         generated_text = asyncio.run(generation_test(prompt="最近在做什么呀", model="soul"))
         # 大小写都可以， eg. SOUL, Soul


### PR DESCRIPTION
add midu & ruyichat api
万得信息 好像没有给出api访问的方法
大智慧 文档不太清楚

midu & ruyichat result
(last) root@MYPC:~/last$ python -m tests.test_llm_api
~/anaconda3/envs/last/lib/python3.8/site-packages/pydantic/_internal/_fields.py:149: UserWarning: Field "model_kwargs" has conflict with protected namespace "model_".

You may be able to resolve this warning by setting `model_config['protected_namespaces'] = ()`.
  warnings.warn(
~/anaconda3/envs/last/lib/python3.8/site-packages/pydantic/_internal/_fields.py:149: UserWarning: Field "model_type" has conflict with protected namespace "model_".

You may be able to resolve this warning by setting `model_config['protected_namespaces'] = ()`.
  warnings.warn(
Aiohttp retry client was not closed
midu 中国的首都是北京，也是政治、文化和教育中心。
~/anaconda3/envs/last/lib/python3.8/threading.py:804: ResourceWarning: unclosed <socket.socket fd=6, family=AddressFamily.AF_INET, type=SocketKind.SOCK_STREAM, proto=6, laddr=('192.168.145.226', 57052), raddr=('182.40.78.155', 443)>
  self._invoke_excepthook = _make_invoke_excepthook()
ResourceWarning: Enable tracemalloc to get the object allocation traceback
/home/rainysponge/anaconda3/envs/last/lib/python3.8/asyncio/selector_events.py:696: ResourceWarning: unclosed transport <_SelectorSocketTransport fd=6>
  _warn(f"unclosed transport {self!r}", ResourceWarning, source=self)
ResourceWarning: Enable tracemalloc to get the object allocation traceback
Aiohttp retry client was not closed
ruyigpt 中国的首都是**北京**。
.
----------------------------------------------------------------------
Ran 2 tests in 5.564s

OK